### PR TITLE
deploying works on dev node

### DIFF
--- a/erc20/scripts/deploy.ts
+++ b/erc20/scripts/deploy.ts
@@ -2,18 +2,16 @@ import { patract, network } from "redspot";
 require("dotenv").config();
 
 const { getContractFactory } = patract;
-const { createSigner, keyring, api } = network;
+const { api } = network;
 
-const uri: string = process.env.MNEMONIC!;
+const signer = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"; // Alice Address
 
 async function run() {
   await api.isReady;
 
-  const signer = createSigner(keyring.createFromUri(uri));
   const contractFactory = await getContractFactory("erc20", signer);
 
-  const balance = await api.query.system.account(signer.address);
-
+  const balance = await api.query.system.account(signer);
   console.log("Balance: ", balance.toHuman());
 
   const contract = await contractFactory.deployed("new", "1000000", {


### PR DESCRIPTION
deploying works when I add the dusty type def in `redspot.config.json`
1) `plasm --dev --ws-external --rpc-external --tmp --rpc-cors all `to run the local node at ws://127.0.0.1:9944
2) `npx redspot run ./scripts/deploy.ts --network dusty`
